### PR TITLE
Change domain to diyejuice.org

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -12,7 +12,7 @@ export default class Footer extends Component {
             <Col md="4">Copyright &copy; 2019 DIY Compendium</Col>
             <Col md="4">
               <a
-                href="https://github.com/ayan4m1/diy-compendium"
+                href="https://github.com/diy-ejuice/diy-compendium"
                 rel="noopener noreferer"
               >
                 GitHub

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-diycompendium.com
+diyejuice.org


### PR DESCRIPTION
Change the CNAME domain used by GitHub Pages to `diyejuice.org` and update the project link to point to the new org's fork of the repo.