### PR TITLE
Featured posts and page mappings

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -70,6 +70,30 @@ const createWordPressPages = async ({ actions, graphql, reporter }) => {
           }
         }
       }
+
+      allWordpressPage(limit: 1000) {
+        edges {
+          node {
+            id
+            path
+            title
+            status
+            content
+            excerpt
+            date
+            modified
+            author {
+              id
+              name
+              avatar_urls {
+                wordpress_24
+                wordpress_48
+                wordpress_96
+              }
+            }
+          }
+        }
+      }
     }
   `);
 
@@ -78,7 +102,7 @@ const createWordPressPages = async ({ actions, graphql, reporter }) => {
     return;
   }
 
-  result.data.allWordpressPost.edges.forEach(({ node }) => {
+  const pageFromNodes = ({ node }) => {
     const { id, path } = node;
 
     reporter.info(`Mapped ${id} to ${path}`);
@@ -87,7 +111,10 @@ const createWordPressPages = async ({ actions, graphql, reporter }) => {
       component,
       path
     });
-  });
+  };
+
+  result.data.allWordpressPost.edges.forEach(pageFromNodes);
+  result.data.allWordpressPage.edges.forEach(pageFromNodes);
 };
 
 exports.createPages = async options => {

--- a/src/pages/featured.js
+++ b/src/pages/featured.js
@@ -1,0 +1,72 @@
+import React from 'react';
+import { graphql, Link } from 'gatsby';
+import PropTypes from 'prop-types';
+
+import Layout from '../components/layout';
+import SEO from '../components/seo';
+import { Container, Row, Col } from 'react-bootstrap';
+
+const FeaturedPage = ({ data }) => {
+  if (!data || !data.allWordpressPost) {
+    return null;
+  }
+
+  const posts = data.allWordpressPost.edges;
+
+  if (!posts) {
+    return null;
+  }
+
+  return (
+    <Layout>
+      <SEO title="Home" />
+      <Container className="mt-5">
+        <Row>
+          <Col md="12">
+            <h1>Featured Posts</h1>
+          </Col>
+          {posts.map(post => {
+            const { node } = post;
+
+            return (
+              <Col md="12" key={node.id}>
+                <Link to={node.path}>
+                  <h3>{node.title}</h3>
+                </Link>
+                <p className="text-muted">
+                  by {node.author.name} on {node.date}
+                </p>
+              </Col>
+            );
+          })}
+        </Row>
+      </Container>
+    </Layout>
+  );
+};
+
+FeaturedPage.displayName = 'FeaturedPage';
+FeaturedPage.propTypes = {
+  data: PropTypes.object
+};
+
+export default FeaturedPage;
+
+export const pageQuery = graphql`
+  query RecentPostQuery {
+    allWordpressPost(sort: { fields: [date], order: [DESC] }) {
+      totalCount
+      edges {
+        node {
+          date
+          path
+          title
+          content
+          author {
+            name
+          }
+        }
+      }
+    }
+  }
+`;


### PR DESCRIPTION
This PR makes two changes.

* [Queries](https://github.com/diy-ejuice/diy-compendium/compare/master...ayan4m1:feature/blog-index?expand=1#diff-fda05457e393bada716f508859bfc604R74) for WP pages and then exports them as Gatsby pages like the posts. Eventually we will want two different components to template these pages differently.

* [Adds](https://github.com/diy-ejuice/diy-compendium/compare/master...ayan4m1:feature/blog-index?expand=1#diff-7c21525361fd8dcc90a20990ad363a10R28) a `/featured` page which shows WP posts in post order (descending)