### PR TITLE
Use env var for GA tracking ID

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -56,7 +56,7 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-gtag',
       options: {
-        trackingId: 'UA-140812424-2',
+        trackingId: process.env.GA_TRACKING_ID,
         head: true,
         anonymize: true
       }


### PR DESCRIPTION
This PR uses an environment variable `GA_TRACKING_ID` instead of a hardcoded tracking ID, allowing us to use different IDs for different environments so as to keep the data collected valid and useful.

I have already defined this variable in Travis so that our builds will continue to use the current tracking ID.