### PR TITLE
Remove author info from WP page template

### DIFF
--- a/src/components/content/wordpress/page.js
+++ b/src/components/content/wordpress/page.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { graphql } from 'gatsby';
 import PropTypes from 'prop-types';
-import { format, parseISO } from 'date-fns';
 import { Container, Row, Col } from 'react-bootstrap';
 
 import './page.scss';
@@ -15,29 +14,16 @@ const WordPressPageContent = ({ data }) => {
   }
 
   const {
-    wordpressPage: {
-      content,
-      title,
-      modified: rawDate,
-      author: { name }
-    }
+    wordpressPage: { content, title }
   } = data;
-
-  const parsed = parseISO(rawDate);
-  const date = format(parsed, "yyyy-MM-dd' at 'HH:mm");
 
   return (
     <Layout>
       <SEO title={title} />
       <Container className="mt-5">
         <Row>
-          <Col md="8" className="mt-4">
+          <Col md="12" className="mt-4">
             <h1>{title}</h1>
-          </Col>
-          <Col md="4" className="mt-4">
-            <span>
-              Written by {name} on {date}
-            </span>
           </Col>
         </Row>
         <hr />


### PR DESCRIPTION
This PR removes the "Written by" info from the WordPress page (but not WordPress post) template component.

![after](https://user-images.githubusercontent.com/266545/66702614-82e9e080-ecd7-11e9-8369-7b2765c45246.PNG)
