### PR TITLE
Unstick the footer

### DIFF
--- a/src/components/footer.scss
+++ b/src/components/footer.scss
@@ -1,14 +1,7 @@
 .diy-footer {
-  width: 100%;
-  position: absolute;
-  bottom: 0;
+  width: 60%;
 
-  > .container > .row {
-    width: 60%;
-    margin: 0 auto;
-
-    > div {
-      text-align: center;
-    }
+  > .container > .row > div {
+    text-align: center;
   }
 }


### PR DESCRIPTION
This PR reverts #7 because it had undesirable side-effects on pages with content longer than one screen height.