### PR TITLE
Tighten up top margin for WP pages

### DIFF
--- a/src/components/content/markdown.js
+++ b/src/components/content/markdown.js
@@ -22,7 +22,7 @@ const MarkdownContent = ({ data }) => {
   return (
     <Layout>
       <SEO title={title} />
-      <Container className="mt-5">
+      <Container>
         <Row>
           <Col md="12" dangerouslySetInnerHTML={{ __html: html }} />
         </Row>

--- a/src/components/content/wordpress/page.js
+++ b/src/components/content/wordpress/page.js
@@ -20,9 +20,9 @@ const WordPressPageContent = ({ data }) => {
   return (
     <Layout>
       <SEO title={title} />
-      <Container className="mt-5">
+      <Container className="mt-3">
         <Row>
-          <Col md="12" className="mt-4">
+          <Col md="12" className="mt-3">
             <h1>{title}</h1>
           </Col>
         </Row>

--- a/src/components/content/wordpress/page.js
+++ b/src/components/content/wordpress/page.js
@@ -20,7 +20,7 @@ const WordPressPageContent = ({ data }) => {
   return (
     <Layout>
       <SEO title={title} />
-      <Container className="mt-3">
+      <Container>
         <Row>
           <Col md="12" className="mt-3">
             <h1>{title}</h1>

--- a/src/components/content/wordpress/post.js
+++ b/src/components/content/wordpress/post.js
@@ -29,7 +29,7 @@ const WordPressPostContent = ({ data }) => {
   return (
     <Layout>
       <SEO title={title} />
-      <Container className="mt-5">
+      <Container>
         <Row>
           <Col md="12" className="mt-4">
             <h1>{title}</h1>

--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -26,7 +26,7 @@ const Layout = ({ children }) => {
   return (
     <Fragment>
       <Header siteTitle={data.site.siteMetadata.title} />
-      <main>{children}</main>
+      <main className="mt-3">{children}</main>
       <Footer />
     </Fragment>
   );

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -7,7 +7,7 @@ import Layout from '~components/layout';
 const NotFoundPage = () => (
   <Layout>
     <SEO title="Not Found" />
-    <Container className="mt-5">
+    <Container>
       <Row>
         <Col md="12">
           <h1>Not Found</h1>

--- a/src/pages/featured.js
+++ b/src/pages/featured.js
@@ -20,7 +20,7 @@ const FeaturedPage = ({ data }) => {
   return (
     <Layout>
       <SEO title="Home" />
-      <Container className="mt-5">
+      <Container>
         <Row>
           <Col md="12">
             <h1>Featured Posts</h1>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -9,7 +9,7 @@ import '../index.scss';
 const IndexPage = () => (
   <Layout>
     <SEO title="Home" />
-    <Container className="mt-5">
+    <Container>
       <Row>
         <Col md="12">
           <h1>Welcome to the DIY Compendium!</h1>


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/266545/72586238-090d5880-38bf-11ea-8313-973d50b46767.PNG)

After:

![after](https://user-images.githubusercontent.com/266545/72586243-0ca0df80-38bf-11ea-86ca-042cc6e60075.PNG)
