### PR TITLE
Fix mobile wrapping of pages with <blockquote>

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -1,3 +1,7 @@
+blockquote {
+  word-break: break-word;
+}
+
 .navbar-brand a {
   color: $white;
 }


### PR DESCRIPTION
Pages that have a block quote, like https://diyejuice.org/quick-start are currently wonky on mobile devices. The page has a right hand gutter that allows horizontal scrolling, which is undesirable. The reason for this is the presence of block quotes which are not being broken up.