### PR TITLE
Generate sitemap.xml during builds

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -4,7 +4,8 @@ module.exports = {
   siteMetadata: {
     title: 'DIY Compendium',
     description: 'A knowledge base with DIY e-liquid mixing information.',
-    author: '@ayan4m1'
+    author: '@ayan4m1',
+    siteUrl: 'https://diyejuice.org'
   },
   plugins: [
     'gatsby-plugin-react-helmet',
@@ -63,6 +64,7 @@ module.exports = {
     },
     'gatsby-plugin-sass',
     'gatsby-transformer-remark',
-    'gatsby-plugin-eslint'
+    'gatsby-plugin-eslint',
+    'gatsby-plugin-sitemap'
   ]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10354,6 +10354,32 @@
         }
       }
     },
+    "gatsby-plugin-sitemap": {
+      "version": "2.2.26",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-sitemap/-/gatsby-plugin-sitemap-2.2.26.tgz",
+      "integrity": "sha512-0kqMM6zD4IWha7Af6kfzwk78870S8XGpOVNJojgtQ83eUu6mKQXdRuae/i52hjclSDsEprbvUfQT0yMxgOotGw==",
+      "requires": {
+        "@babel/runtime": "^7.7.6",
+        "minimatch": "^3.0.4",
+        "pify": "^3.0.0",
+        "sitemap": "^1.13.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
+          "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        }
+      }
+    },
     "gatsby-react-router-scroll": {
       "version": "2.1.20",
       "resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.20.tgz",
@@ -20322,6 +20348,15 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.4.tgz",
       "integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
     },
+    "sitemap": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sitemap/-/sitemap-1.13.0.tgz",
+      "integrity": "sha1-Vpy+IYAgKSamKiZs094Jyc60P4M=",
+      "requires": {
+        "underscore": "^1.7.0",
+        "url-join": "^1.1.0"
+      }
+    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -22575,6 +22610,11 @@
         }
       }
     },
+    "underscore": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.2.tgz",
+      "integrity": "sha512-D39qtimx0c1fI3ya1Lnhk3E9nONswSKhnffBI0gME9C99fYOkNi04xs8K6pePLhvl1frbDemkaBQ5ikWllR2HQ=="
+    },
     "underscore.string": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
@@ -22930,6 +22970,11 @@
           "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
         }
       }
+    },
+    "url-join": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
+      "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg="
     },
     "url-loader": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "gatsby-plugin-react-helmet": "^3.1.21",
     "gatsby-plugin-sass": "^2.1.27",
     "gatsby-plugin-sharp": "^2.3.13",
+    "gatsby-plugin-sitemap": "^2.2.26",
     "gatsby-source-filesystem": "^2.1.46",
     "gatsby-source-wordpress": "^3.1.57",
     "gatsby-transformer-remark": "^2.6.48",


### PR DESCRIPTION
This PR adds [gatsby-plugin-sitemap](https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/) which will generate a sitemap.xml during production builds. This sitemap is used by crawlers to improve search indexing. It is important for integration of Docsearch.