### PR TITLE
Fix style load on non-index pages

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,7 +1,1 @@
-/**
- * Implement Gatsby's Browser APIs in this file.
- *
- * See: https://www.gatsbyjs.org/docs/browser-apis/
- */
-
-// You can delete this file if you're not using it
+import './src/index.scss';

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -4,8 +4,6 @@ import { Container, Row, Col } from 'react-bootstrap';
 import SEO from '~components/seo';
 import Layout from '~components/layout';
 
-import '../index.scss';
-
 const IndexPage = () => (
   <Layout>
     <SEO title="Home" />


### PR DESCRIPTION
This PR resolves an issue where the `index.scss` file was not being imported on all pages. Importing it in gatsby-browser makes it apply to all pages.