### PR TITLE
Stop running gh-pages twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ cache:
   directories:
     - node_modules
 script:
-  - npm run deploy
+  - npm run build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 os: linux
 node_js:
-  - 'stable'
+  - stable
 deploy:
   provider: pages
   skip-cleanup: true
-  github-token: $GITHUB_TOKEN
+  github-token: "$GITHUB_TOKEN"
   local_dir: public
   keep-history: true
   on:

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
     "gatsby-plugin-eslint": "^2.0.8",
-    "gh-pages": "^2.2.0",
     "husky": "^4.0.6",
     "lint-staged": "^9.5.0",
     "prettier": "^1.19.1",
@@ -64,8 +63,7 @@
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \"",
-    "deploy": "gatsby build && gh-pages -d public -r \"https://$GITHUB_TOKEN@github.com/$TRAVIS_REPO_SLUG\""
+    "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing \""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes PR builds in Travis by not running the gh-pages part unless it is a commit to master. PR builds do not get the environment variables needed in order to do this. Luckily it is being run twice right now so dropping one of them is fine.