### PR TITLE
Add site description from front matter for SEO

### DIFF
--- a/src/components/markdown/page.js
+++ b/src/components/markdown/page.js
@@ -15,13 +15,13 @@ const MarkdownPage = ({ data }) => {
   const {
     markdownRemark: {
       html,
-      frontmatter: { title }
+      frontmatter: { title, description }
     }
   } = data;
 
   return (
     <Layout>
-      <SEO title={title} description={title} />
+      <SEO title={title} description={description} />
       <Container>
         <Row>
           <Col md="12" dangerouslySetInnerHTML={{ __html: html }} />
@@ -33,7 +33,9 @@ const MarkdownPage = ({ data }) => {
 
 MarkdownPage.displayName = 'MarkdownContent';
 MarkdownPage.propTypes = {
-  data: PropTypes.object
+  data: PropTypes.shape({
+    markdownRemark: PropTypes.arrayOf(PropTypes.object)
+  })
 };
 
 export default MarkdownPage;

--- a/src/docs/supplies/bottles.md
+++ b/src/docs/supplies/bottles.md
@@ -2,6 +2,7 @@
 path: '/supplies/bottles'
 slug: 'bottles'
 title: 'Supplies - Bottles'
+description: 'Info about bottle materials, styles, and suppliers.'
 ---
 
 # Bottles


### PR DESCRIPTION
Use the OpenGraph description field to expose a description for the page. This is added to the front matter of any page that wants to take advantage of it and produces better summaries for search engines and services like Discord. I only added the description for one page to prevent introducing extra conflicts.